### PR TITLE
Fix improper filter for old windows

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -360,7 +360,7 @@ var render = ({
           <td style={{ textAlign: "left" }}>
             <select id="sale-window" value={buyWindow}
                     onChange={e => update({ buyWindow: e.target.value })}>
-              {days.filter((d, i) => i <= Number(today)).map((d, i) => {
+              {days.map((d,i) => i).filter((i) => i >= Number(today)).map((i) => {
                 return <option key={i} value={i}>Window #{i}</option>
               })}
             </select>


### PR DESCRIPTION
There was a feature added that was intended to filter out "old" windows in the "Buy EOS" pane.  However, the comparison was reversed and the resulting `.map` would have munged indices as a result.  Now the array is converted to its ordinals, then filtered and lastly mapped to the JSX.