### PR TITLE
Hide the Buy EOS link until a claim-key is registered.

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -230,11 +230,11 @@ var render = ({
           <th>Token balances</th>
           <td style={{ textAlign: "left" }}>
             {formatETH(eth_balance.div(WAD))} ETH
-            <a href="#" id="buy-link"
+            {publicKey ? <a href="#" id="buy-link"
                style={{ marginLeft: "1rem", float: "right" }}
                onClick={event => (event.preventDefault(), showPane('buy'))}>
               Buy EOS tokens
-            </a>
+            </a> : <span></span>}
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
This change will hide the buy link leaving and make the user use 'Generate EOS key' first.

Without this, the second we go live there is an opportunity for someone to come in and buy some EOS tokens but leave without creating a claim key.  I am unaware of any way we can deliver the EOS tokens if they do that.